### PR TITLE
Ensure MetaMask chain list is non-empty

### DIFF
--- a/src/core/integrations/metamask/MetaMaskChains.ts
+++ b/src/core/integrations/metamask/MetaMaskChains.ts
@@ -2,9 +2,15 @@ import * as wagmiChains from 'wagmi/chains';
 import type { Chain } from 'wagmi/chains';
 
 // Gather all chain objects exported from wagmi
-export const metaMaskChains = Object.values(wagmiChains).filter(
+const allChains = Object.values(wagmiChains).filter(
   (chain) => typeof chain === 'object' && chain !== null && 'id' in (chain as any)
 ) as Chain[];
+
+if (allChains.length === 0) {
+  throw new Error('No chains found in wagmi');
+}
+
+export const metaMaskChains = allChains as unknown as [Chain, ...Chain[]];
 
 export const chainIdToName = metaMaskChains.reduce((merged, chain) => {
   merged[chain.id] = chain.name;


### PR DESCRIPTION
## Summary
- ensure MetaMask chains array is non-empty and satisfies wagmi config tuple requirement

## Testing
- `npm test` *(fails: Jest encountered an unexpected token)*


------
https://chatgpt.com/codex/tasks/task_e_689846ea21ec833385b3a7911be1c0dc