### PR TITLE
fix highcharts module imports and web-vitals usage

### DIFF
--- a/src/core/components/FirstPageStats/PieChart/index.tsx
+++ b/src/core/components/FirstPageStats/PieChart/index.tsx
@@ -7,11 +7,8 @@ import Highcharts from "highcharts";
 import HighchartsReact from "highcharts-react-official";
 import numberFormat from "../../../utils/numberFormat";
 
-// Initialize the 3D module for Highcharts. The module's type definitions
-// export the Highcharts namespace rather than the initialization function, so
-// we cast to `any` before invoking.
-import Highcharts3d from "highcharts/highcharts-3d";
-(Highcharts3d as any)(Highcharts);
+// Load the 3D module. It self-registers with Highcharts upon import.
+import "highcharts/highcharts-3d";
 
 const pieColors = [
     "#1a5048",

--- a/src/core/components/FirstPageStats/PieChart/index.tsx
+++ b/src/core/components/FirstPageStats/PieChart/index.tsx
@@ -4,11 +4,14 @@ import AssetDTO, {AssetType} from "../../../domain/AssetDTO";
 import noExponents from "../../../utils/noExponents";
 import PriceService from "../../../services/PriceService";
 import Highcharts from "highcharts";
-import highcharts3d from 'highcharts/modules/3d'
 import HighchartsReact from "highcharts-react-official";
 import numberFormat from "../../../utils/numberFormat";
 
-highcharts3d(Highcharts);
+// Initialize the 3D module for Highcharts. The module's type definitions
+// export the Highcharts namespace rather than the initialization function, so
+// we cast to `any` before invoking.
+import Highcharts3d from "highcharts/highcharts-3d";
+(Highcharts3d as any)(Highcharts);
 
 const pieColors = [
     "#1a5048",

--- a/src/core/components/FirstPageStats/TreeChart/index.tsx
+++ b/src/core/components/FirstPageStats/TreeChart/index.tsx
@@ -5,18 +5,14 @@ import noExponents from "../../../utils/noExponents";
 import PriceService from "../../../services/PriceService";
 import Highcharts from "highcharts";
 import HighchartsReact from "highcharts-react-official";
-import DataModule from "highcharts/modules/data";
-import AccessibilityModule from "highcharts/modules/accessibility";
-import HeatmapModule from "highcharts/modules/heatmap";
-import TreemapModule from "highcharts/modules/treemap";
 
-// Initialize Highcharts modules. The module definitions export the Highcharts
-// namespace rather than the initialization function, therefore we cast to
-// `any` before invoking them.
-(DataModule as any)(Highcharts);
-(AccessibilityModule as any)(Highcharts);
-(HeatmapModule as any)(Highcharts);
-(TreemapModule as any)(Highcharts);
+// Load Highcharts modules for data, accessibility, heatmap, and treemap support.
+// These modules self-register with Highcharts when imported, so no explicit
+// initialization call is required.
+import "highcharts/modules/data";
+import "highcharts/modules/accessibility";
+import "highcharts/modules/heatmap";
+import "highcharts/modules/treemap";
 
 const treemapColors = [
     "#103b34",

--- a/src/core/components/FirstPageStats/TreeChart/index.tsx
+++ b/src/core/components/FirstPageStats/TreeChart/index.tsx
@@ -4,17 +4,19 @@ import AssetDTO, {AssetType} from "../../../domain/AssetDTO";
 import noExponents from "../../../utils/noExponents";
 import PriceService from "../../../services/PriceService";
 import Highcharts from "highcharts";
+import HighchartsReact from "highcharts-react-official";
 import DataModule from "highcharts/modules/data";
 import AccessibilityModule from "highcharts/modules/accessibility";
 import HeatmapModule from "highcharts/modules/heatmap";
 import TreemapModule from "highcharts/modules/treemap";
-import HighchartsReact from "highcharts-react-official";
 
-// initialize Highcharts modules
-DataModule(Highcharts);
-AccessibilityModule(Highcharts);
-HeatmapModule(Highcharts);
-TreemapModule(Highcharts);
+// Initialize Highcharts modules. The module definitions export the Highcharts
+// namespace rather than the initialization function, therefore we cast to
+// `any` before invoking them.
+(DataModule as any)(Highcharts);
+(AccessibilityModule as any)(Highcharts);
+(HeatmapModule as any)(Highcharts);
+(TreemapModule as any)(Highcharts);
 
 const treemapColors = [
     "#103b34",

--- a/src/reportWebVitals.ts
+++ b/src/reportWebVitals.ts
@@ -1,7 +1,7 @@
-import type { ReportCallback } from 'web-vitals';
+import type { MetricType } from 'web-vitals';
 
-const reportWebVitals = (onPerfEntry?: ReportCallback) => {
-    if (onPerfEntry && onPerfEntry instanceof Function) {
+const reportWebVitals = (onPerfEntry?: (metric: MetricType) => void) => {
+    if (onPerfEntry && typeof onPerfEntry === 'function') {
         import('web-vitals').then(({onCLS, onINP, onFCP, onLCP, onTTFB}) => {
             onCLS(onPerfEntry);
             onINP(onPerfEntry);

--- a/src/reportWebVitals.ts
+++ b/src/reportWebVitals.ts
@@ -1,10 +1,10 @@
-import {ReportHandler} from 'web-vitals';
+import type { ReportCallback } from 'web-vitals';
 
-const reportWebVitals = (onPerfEntry?: ReportHandler) => {
+const reportWebVitals = (onPerfEntry?: ReportCallback) => {
     if (onPerfEntry && onPerfEntry instanceof Function) {
-        import('web-vitals').then(({onCLS, onFID, onFCP, onLCP, onTTFB}) => {
+        import('web-vitals').then(({onCLS, onINP, onFCP, onLCP, onTTFB}) => {
             onCLS(onPerfEntry);
-            onFID(onPerfEntry);
+            onINP(onPerfEntry);
             onFCP(onPerfEntry);
             onLCP(onPerfEntry);
             onTTFB(onPerfEntry);


### PR DESCRIPTION
## Summary
- fix Highcharts 3D import path and module initialization
- cast Highcharts modules to `any` to allow initialization
- update web-vitals integration to use current API

## Testing
- `CI=true npm test`
- `CI=true npm run build` *(fails: Module not found: Error: Can't resolve 'vm' in 'node_modules/asn1.js/lib/asn1')*

------
https://chatgpt.com/codex/tasks/task_e_689c951945bc8333b5d3bb34111d3135