### PR TITLE
Add dark themed landing page for ColdWallet

### DIFF
--- a/src/core/components/landing/index.css
+++ b/src/core/components/landing/index.css
@@ -1,0 +1,39 @@
+.landing {
+    background: linear-gradient(to bottom, #000000 0%, #001a00 100%);
+    color: #e6ffe6;
+    min-height: 100vh;
+    padding: 40px 20px;
+    font-family: 'Segoe UI', sans-serif;
+}
+
+.section {
+    max-width: 900px;
+    margin: 0 auto 40px;
+    line-height: 1.6;
+}
+
+.landing h1, .landing h2 {
+    color: #86ff86;
+}
+
+.buy-buttons {
+    margin-top: 20px;
+}
+
+.buy-button {
+    background-color: #006400;
+    color: #ffffff;
+    padding: 12px 20px;
+    margin-right: 16px;
+    text-decoration: none;
+    border-radius: 4px;
+    display: inline-block;
+}
+
+.buy-button:hover {
+    background-color: #008000;
+}
+
+.landing a {
+    color: #6bff9d;
+}

--- a/src/core/components/landing/index.tsx
+++ b/src/core/components/landing/index.tsx
@@ -1,0 +1,53 @@
+import './index.css';
+
+export default function Landing() {
+    return (
+        <div className="landing">
+            <section className="section">
+                <h1>ColdWallet</h1>
+                <p>
+                    Decentralized, anonymous and free open-source financial dashboard running entirely
+                    on your device.
+                </p>
+                <div className="buy-buttons">
+                    <a className="buy-button" href="https://www.sushi.com/ethereum/pool/v3/0x79d1ad6e84819e3e9fb7f73512c49203a4037750" target="_blank" rel="noopener noreferrer">Buy on SushiSwap V3</a>
+                    <a className="buy-button" href="https://www.sushi.com/ethereum/pool/v2/0xe9fb36429fa2da71ec7c7a2d50bef0939ad920bd" target="_blank" rel="noopener noreferrer">Buy on SushiSwap V2</a>
+                </div>
+            </section>
+
+            <section className="section">
+                <h2>Why ColdWallet?</h2>
+                <ul>
+                    <li>Front-end as a Service (FaaS): all code runs locally on your machine.</li>
+                    <li>Your data is encrypted and never leaves your device.</li>
+                    <li>Integrations with MetaMask, Binance, OKX, Monobank and top exchanges via CCXT.</li>
+                    <li>Manual asset entry for any currency.</li>
+                    <li>Ready-to-use MVP at <a href="https://cold-wallet.app" target="_blank" rel="noopener noreferrer">cold-wallet.app</a>.</li>
+                </ul>
+            </section>
+
+            <section className="section">
+                <h2>CWT Token</h2>
+                <p>Contract: <a href="https://etherscan.io/token/0xa9995a928EbFa3030B86Ab62e85007e1AB7eb208" target="_blank" rel="noopener noreferrer">0xa9995a928EbFa3030B86Ab62e85007e1AB7eb208</a></p>
+                <p>Total supply: 1,000,000,000 CWT</p>
+                <p>Utility token powering ColdWallet development and unlocking premium features with discounts when paying in CWT.</p>
+            </section>
+
+            <section className="section">
+                <h2>Roadmap</h2>
+                <ul>
+                    <li><strong>H1 2025:</strong> MVP live and token launched on Ethereum.</li>
+                    <li><strong>H2 2025:</strong> Major redesign and more wallet integrations.</li>
+                    <li><strong>H1 2026:</strong> Balance history, premium features payable with CWT or discounted; AI-powered portfolio analysis and advice.</li>
+                </ul>
+            </section>
+
+            <section className="section">
+                <p>
+                    <a href="/terms">Terms of Use</a> | <a href="/privacy-policy">Privacy Policy</a>
+                </p>
+            </section>
+        </div>
+    );
+}
+

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,6 +7,7 @@ import reportWebVitals from './reportWebVitals';
 import Terms from "./core/components/legal/Terms";
 import PrivacyPolicy from "./core/components/legal/PrivacyPolicy";
 import ErrorPage from "./core/components/ErrorPage";
+import Landing from "./core/components/landing";
 
 const router = createBrowserRouter([
     {
@@ -26,6 +27,10 @@ const router = createBrowserRouter([
     {
         path: "/privacy-policy",
         element: <PrivacyPolicy/>,
+    },
+    {
+        path: "/landing",
+        element: <Landing/>,
     },
 ]);
 


### PR DESCRIPTION
## Summary
- Add standalone dark-themed landing page with project overview, token info, buy links, and roadmap.
- Link landing page under `/landing` route alongside existing legal pages.

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a438e94634833389f6ffe368ae3be7