### PR TITLE
docs: rewrite README using landing page copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,83 +1,32 @@
-# Getting Started with Create React App
+# ColdWallet
 
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+Decentralized, anonymous and free open-source financial dashboard running entirely on your device.
 
-## Available Scripts
+[Buy on SushiSwap](https://www.sushi.com/ethereum/swap?token0=0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48&token1=0xa9995a928EbFa3030B86Ab62e85007e1AB7eb208)  
+[Watch CWT trading on CoinMarketCap DEX](https://dex.coinmarketcap.com/token/ethereum/0xa9995a928ebfa3030b86ab62e85007e1ab7eb208/)  
+[Whitepaper](public/whitepaper.pdf)
 
-In the project directory, you can run:
+## Why ColdWallet?
 
-### `npm start`
+- Front-end as a Service (FaaS): all code runs locally on your machine.
+- Your data is encrypted and never leaves your device.
+- Integrations with MetaMask, Binance, OKX, Monobank and top exchanges via CCXT.
+- Manual asset entry for any currency.
+- Ready-to-use MVP at [cold-wallet.app](https://cold-wallet.app).
 
-Runs the app in the development mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in your browser.
+## CWT Token
 
-The page will reload when you make changes.\
-You may also see any lint errors in the console.
+- Contract: [0xa9995a928EbFa3030B86Ab62e85007e1AB7eb208](https://etherscan.io/token/0xa9995a928EbFa3030B86Ab62e85007e1AB7eb208)
+- Total supply: 1,000,000,000 CWT
+- Utility token powering ColdWallet development and unlocking premium features with discounts when paying in CWT.
 
-### `npm test`
+## Roadmap
 
-Launches the test runner in the interactive watch mode.\
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more
-information.
+- **H1 2025:** MVP live and token launched on Ethereum.
+- **H2 2025:** Major redesign and more wallet integrations.
+- **H1 2026:** Balance history, premium features payable with CWT or discounted; AI-powered portfolio analysis and advice.
 
-### `npm run build`
+## Terms and Privacy
 
-Builds the app for production to the `build` folder.\
-It correctly bundles React in production mode and optimizes the build for the best performance.
+[Terms of Use](https://cold-wallet.app/terms) | [Privacy Policy](https://cold-wallet.app/privacy-policy)
 
-The build is minified and the filenames include the hashes.\
-Your app is ready to be deployed!
-
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
-
-### `npm run eject`
-
-**Note: this is a one-way operation. Once you `eject`, you can't go back!**
-
-If you aren't satisfied with the build tool and configuration choices, you can `eject` at any time. This command will
-remove the single build dependency from your project.
-
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right
-into your project so you have full control over them. All of the commands except `eject` will still work, but they will
-point to the copied scripts so you can tweak them. At this point you're on your own.
-
-You don't have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you
-shouldn't feel obligated to use this feature. However we understand that this tool wouldn't be useful if you couldn't
-customize it when you are ready for it.
-
-## Learn More
-
-You can learn more in
-the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
-
-To learn React, check out the [React documentation](https://reactjs.org/).
-
-### Code Splitting
-
-This section has moved
-here: [https://facebook.github.io/create-react-app/docs/code-splitting](https://facebook.github.io/create-react-app/docs/code-splitting)
-
-### Analyzing the Bundle Size
-
-This section has moved
-here: [https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size](https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size)
-
-### Making a Progressive Web App
-
-This section has moved
-here: [https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app](https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app)
-
-### Advanced Configuration
-
-This section has moved
-here: [https://facebook.github.io/create-react-app/docs/advanced-configuration](https://facebook.github.io/create-react-app/docs/advanced-configuration)
-
-### Deployment
-
-This section has moved
-here: [https://facebook.github.io/create-react-app/docs/deployment](https://facebook.github.io/create-react-app/docs/deployment)
-
-### `npm run build` fails to minify
-
-This section has moved
-here: [https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify](https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify)


### PR DESCRIPTION
## Summary
- replace default Create React App README with ColdWallet marketing copy from landing page
- include feature highlights, CWT token info, roadmap, and legal links

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68b1fe95bf0c8333bf610cac5f92e514